### PR TITLE
Optimize the (common?) case where you don't have to change the image bitdepth

### DIFF
--- a/code/png.py
+++ b/code/png.py
@@ -2103,7 +2103,10 @@ class Reader:
         def iterscale():
             for row in pixels:
                 yield map(lambda x: int(round(x*factor)), row)
-        return width, height, iterscale(), meta
+        if maxval == targetmaxval:
+            return width, height, pixels, meta
+        else:
+            return width, height, iterscale(), meta
 
     def asRGB8(self):
         """Return the image data as an RGB pixels with 8-bits per


### PR DESCRIPTION
With this optimization the time to read a 800x800 image with no filters when from 4.7s to 0.8s.
