### PR TITLE
Optimize iterstraight

### DIFF
--- a/code/cpngfilters.pyx
+++ b/code/cpngfilters.pyx
@@ -7,8 +7,8 @@ cimport cpython.array
 
 
 # TODO: I don't know how can I not return any value (void doesn't work)
-cpdef int undo_filter_sub(int filter_unit, unsigned char[:] scanline,
-                          unsigned char[:] previous, unsigned char[:] result) nogil:
+def undo_filter_sub(int filter_unit, unsigned char[:] scanline,
+                    unsigned char[:] previous, unsigned char[:] result):
     """Undo sub filter."""
 
     cdef int l = result.shape[0]
@@ -23,11 +23,10 @@ cpdef int undo_filter_sub(int filter_unit, unsigned char[:] scanline,
         a = result[ai]
         result[i] = (x + a) & 0xff
         ai += 1
-    return 0
 
 
-cpdef int undo_filter_up(int filter_unit, unsigned char[:] scanline,
-                         unsigned char[:] previous, unsigned char[:] result) nogil:
+def undo_filter_up(int filter_unit, unsigned char[:] scanline,
+                   unsigned char[:] previous, unsigned char[:] result):
     """Undo up filter."""
 
     cdef int i
@@ -41,8 +40,8 @@ cpdef int undo_filter_up(int filter_unit, unsigned char[:] scanline,
     return 0
 
 
-cpdef int undo_filter_average(int filter_unit, unsigned char[:] scanline,
-                              unsigned char[:] previous, unsigned char[:] result) nogil:
+def undo_filter_average(int filter_unit, unsigned char[:] scanline,
+                        unsigned char[:] previous, unsigned char[:] result):
     """Undo up filter."""
 
     cdef int i, ai
@@ -62,8 +61,8 @@ cpdef int undo_filter_average(int filter_unit, unsigned char[:] scanline,
     return 0
 
 
-cpdef int undo_filter_paeth(int filter_unit, unsigned char[:] scanline,
-                            unsigned char[:] previous, unsigned char[:] result) nogil:
+def undo_filter_paeth(int filter_unit, unsigned char[:] scanline,
+                      unsigned char[:] previous, unsigned char[:] result):
     """Undo Paeth filter."""
 
     # Also used for ci.
@@ -90,12 +89,11 @@ cpdef int undo_filter_paeth(int filter_unit, unsigned char[:] scanline,
             pr = b
         else:
             pr = c
-        result[i] = (x + pr) & 0xff
+        result[i] = x + pr
         ai += 1
-    return 0
 
 
-cpdef int convert_rgb_to_rgba(unsigned char[:] row, unsigned char[:] result) nogil:
+def convert_rgb_to_rgba(unsigned char[:] row, unsigned char[:] result):
     cdef int i, l, j, k
     l = min(row.shape[0] / 3, result.shape[0] / 4)
     for i in range(l):
@@ -104,10 +102,9 @@ cpdef int convert_rgb_to_rgba(unsigned char[:] row, unsigned char[:] result) nog
         result[k] = row[j]
         result[k + 1] = row[j + 1]
         result[k + 2] = row[j + 2]
-    return 0
 
 
-cpdef int convert_l_to_rgba(unsigned char[:] row, unsigned char[:] result) nogil:
+def convert_l_to_rgba(unsigned char[:] row, unsigned char[:] result):
     cdef int i, l, j, k, lum
     l = min(row.shape[0], result.shape[0] / 4)
     for i in range(l):
@@ -117,10 +114,9 @@ cpdef int convert_l_to_rgba(unsigned char[:] row, unsigned char[:] result) nogil
         result[k] = lum
         result[k + 1] = lum
         result[k + 2] = lum
-    return 0
 
 
-cpdef int convert_la_to_rgba(unsigned char[:] row, unsigned char[:] result) nogil:
+def convert_la_to_rgba(unsigned char[:] row, unsigned char[:] result):
     cdef int i, l, j, k, lum
     l = min(row.shape[0] / 2, result.shape[0] / 4)
     for i in range(l):
@@ -131,4 +127,3 @@ cpdef int convert_la_to_rgba(unsigned char[:] row, unsigned char[:] result) nogi
         result[k + 1] = lum
         result[k + 2] = lum
         result[k + 3] = row[j + 1]
-    return 0

--- a/code/cpngfilters.pyx
+++ b/code/cpngfilters.pyx
@@ -6,9 +6,8 @@ from libc.stdlib cimport abs as c_abs
 cimport cpython.array
 
 
-# TODO: I don't know how can I not return any value (void doesn't work)
-def undo_filter_sub(int filter_unit, unsigned char[:] scanline,
-                    unsigned char[:] previous, unsigned char[:] result):
+def undo_filter_sub(int filter_unit, unsigned char[::1] scanline,
+                    unsigned char[::1] previous, unsigned char[::1] result):
     """Undo sub filter."""
 
     cdef int l = result.shape[0]
@@ -25,8 +24,8 @@ def undo_filter_sub(int filter_unit, unsigned char[:] scanline,
         ai += 1
 
 
-def undo_filter_up(int filter_unit, unsigned char[:] scanline,
-                   unsigned char[:] previous, unsigned char[:] result):
+def undo_filter_up(int filter_unit, unsigned char[::1] scanline,
+                   unsigned char[::1] previous, unsigned char[::1] result):
     """Undo up filter."""
 
     cdef int i
@@ -40,8 +39,8 @@ def undo_filter_up(int filter_unit, unsigned char[:] scanline,
     return 0
 
 
-def undo_filter_average(int filter_unit, unsigned char[:] scanline,
-                        unsigned char[:] previous, unsigned char[:] result):
+def undo_filter_average(int filter_unit, unsigned char[::1] scanline,
+                        unsigned char[::1] previous, unsigned char[::1] result):
     """Undo up filter."""
 
     cdef int i, ai
@@ -61,8 +60,8 @@ def undo_filter_average(int filter_unit, unsigned char[:] scanline,
     return 0
 
 
-def undo_filter_paeth(int filter_unit, unsigned char[:] scanline,
-                      unsigned char[:] previous, unsigned char[:] result):
+def undo_filter_paeth(int filter_unit, unsigned char[::1] scanline,
+                      unsigned char[::1] previous, unsigned char[::1] result):
     """Undo Paeth filter."""
 
     # Also used for ci.
@@ -93,7 +92,7 @@ def undo_filter_paeth(int filter_unit, unsigned char[:] scanline,
         ai += 1
 
 
-def convert_rgb_to_rgba(unsigned char[:] row, unsigned char[:] result):
+def convert_rgb_to_rgba(unsigned char[::1] row, unsigned char[::1] result):
     cdef int i, l, j, k
     l = min(row.shape[0] / 3, result.shape[0] / 4)
     for i in range(l):
@@ -104,7 +103,7 @@ def convert_rgb_to_rgba(unsigned char[:] row, unsigned char[:] result):
         result[k + 2] = row[j + 2]
 
 
-def convert_l_to_rgba(unsigned char[:] row, unsigned char[:] result):
+def convert_l_to_rgba(unsigned char[::1] row, unsigned char[::1] result):
     cdef int i, l, j, k, lum
     l = min(row.shape[0], result.shape[0] / 4)
     for i in range(l):
@@ -116,7 +115,7 @@ def convert_l_to_rgba(unsigned char[:] row, unsigned char[:] result):
         result[k + 2] = lum
 
 
-def convert_la_to_rgba(unsigned char[:] row, unsigned char[:] result):
+def convert_la_to_rgba(unsigned char[::1] row, unsigned char[::1] result):
     cdef int i, l, j, k, lum
     l = min(row.shape[0] / 2, result.shape[0] / 4)
     for i in range(l):


### PR DESCRIPTION
This took me a while, as I had some false starts. Reading a 800x800 image from memory was taking ~130ms on my laptop, the main offenders being:

iterstraight - 50ms
cpngfilters.undo_filter_paeth - 37ms
{built-in method decompress} - 16ms
...

iterstraight spends most of its time extending the a array to then pass a slice of it. Very often (depends on the IDAT chunks) it can just pass a slice the "some" array. I take advantage of this to create a fast-path for this case (the while loop).

This takes iterstraight from 50ms down to 2ms, putting undo_filter_\* back as the top offenders.

I found a way to make undo_filter_\* faster, specifying in Cython that the elements over which it iterates are contiguous in memory. This takes undo_filter_paeth down to 25ms.

In total this pull request saves ~60ms, making pypng almost twice as fast as it was before (in total ~70ms to load a 800x800 image from memory).
