### PR TITLE
Warning handled for Python3: DeprecationWarning: tostring()

### DIFF
--- a/code/png.py
+++ b/code/png.py
@@ -196,18 +196,26 @@ def isarray(x):
         # Because on Python 2.2 array.array is not a type.
         return False
 
-try:  # see :pyver:old
-    array.tostring
+try:
+    array.tobytes
 except AttributeError:
-    def tostring(row):
-        l = len(row)
-        return struct.pack('%dB' % l, *row)
+    try:  # see :pyver:old
+        array.tostring
+    except AttributeError:
+        def tostring(row):
+            l = len(row)
+            return struct.pack('%dB' % l, *row)
+    else:
+        def tostring(row):
+            """Convert row of bytes to string.  Expects `row` to be an
+            ``array``.
+            """
+            return row.tostring()
 else:
     def tostring(row):
-        """Convert row of bytes to string.  Expects `row` to be an
-        ``array``.
+        """ Python3 definition, array.tostring() is deprecated in Python3
         """
-        return row.tostring()
+        return row.tobytes()
 
 # Conditionally convert to bytes.  Works on Python 2 and Python 3.
 try:


### PR DESCRIPTION
It seems that 2to3 script does not handle the "tostring" methods very well. So I manually wrap the code to let Python3 use "tobytes" by default.

This will get rid of the annoying deprecation warnning each time tostring() is called. When I generate hundreds of images, the warnings just flush everything on screen.

I am new to github, and this is my first time using pull request. Please let me know if I can do it in a better way. pypng is a wonderful library, and I am willing to help.
