### PR TITLE
Use bytes consistently on Python3

### DIFF
--- a/code/png.py
+++ b/code/png.py
@@ -804,7 +804,7 @@ class Writer:
         if len(data):
             compressed = compressor.compress(tostring(data))
         else:
-            compressed = ''
+            compressed = strtobytes('')
         flushed = compressor.flush()
         if len(compressed) or len(flushed):
             write_chunk(outfile, 'IDAT', compressed + flushed)


### PR DESCRIPTION
While using a tool that uses pypng, I got this traceback (Python 3):

```
  File "/home/vkurup/dev/dr_tea/dr_tea/importer/processing.py", line 50, in png_to_dwe
    writer.write(f, result)
  File "/home/vkurup/.virtualenvs/dr-tea/lib/python3.3/site-packages/png.py", line 643, in write
    nrows = self.write_passes(outfile, rows)
  File "/home/vkurup/.virtualenvs/dr-tea/lib/python3.3/site-packages/png.py", line 815, in write_passes
    write_chunk(outfile, 'IDAT', compressed + flushed)
TypeError: Can't convert 'bytes' object to str implicitly
```

The PR attached fixes it. Thanks for considering this issue.
