### PR TITLE
Updated curl flags in README.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -46,7 +46,7 @@ that you can copy png.py into your application and distribute it.  The
 following "curl" command should copy the latest version into your
 current directory:
 
-curl -O https://raw.github.com/drj11/pypng/master/code/png.py
+curl -LO https://raw.github.com/drj11/pypng/master/code/png.py
 
 
 RELEASE NOTES


### PR DESCRIPTION
The url redirects. Providing -L tells curl to follow the redirect.
       -L, --location
              (HTTP/HTTPS)  If  the server reports that the requested page has moved to a dif-
              ferent location (indicated with a Location: header and  a  3XX  response  code),
              this  option  will make curl redo the request on the new place.
