### PR TITLE
Remove unused variable

### DIFF
--- a/code/png.py
+++ b/code/png.py
@@ -325,7 +325,7 @@ def check_color(c, greyscale, which):
         return c
     if greyscale:
         try:
-            l = len(c)
+            len(c)
         except TypeError:
             c = (c,)
         if len(c) != 1:


### PR DESCRIPTION
The local `l` is assigned to but never used.  `len(c)` is only used as a type check.