### PR TITLE
Fix undefined name "tag"

### DIFF
--- a/code/png.py
+++ b/code/png.py
@@ -1416,7 +1416,7 @@ class Reader:
                   % (type, length))
             checksum = self.file.read(4)
             if len(checksum) != 4:
-                raise ValueError('Chunk %s too short for checksum.', tag)
+                raise ValueError('Chunk %s too short for checksum.' % type)
             if seek and type != seek:
                 continue
             verify = zlib.crc32(strtobytes(type))


### PR DESCRIPTION
`tag` is not defined, so change it to `type` like the other exceptions in this method.