### PR TITLE
Alternative approach to solve #69: Use named tuple

### DIFF
--- a/code/png.py
+++ b/code/png.py
@@ -156,7 +156,7 @@ import sys
 # http://www.python.org/doc/2.4.4/lib/module-warnings.html
 import warnings
 import zlib
-
+import collections
 from array import array
 from functools import reduce
 
@@ -185,6 +185,10 @@ _adam7 = ((0, 0, 8, 8),
           (0, 2, 2, 4),
           (1, 0, 2, 2),
           (0, 1, 1, 2))
+
+# Holds information about the 'pHYs' chunk (used by the Reader, only)
+_Resolution = collections.namedtuple('_Resolution', 'x y unit_is_meter')
+
 
 def group(s, n):
     # See http://www.python.org/doc/2.6/library/functions.html#zip
@@ -1918,9 +1922,9 @@ class Reader:
             if a is not None:
                 meta[attr] = a
         if getattr(self, 'x_pixels_per_unit', None):
-            meta['physical'] = {'x': self.x_pixels_per_unit,
-                                'y': self.y_pixels_per_unit,
-                                'unit_is_meter': self.unit_is_meter}
+            meta['physical'] = _Resolution(self.x_pixels_per_unit,
+                                           self.y_pixels_per_unit,
+                                           self.unit_is_meter)
         if self.plte:
             meta['palette'] = self.palette()
         return self.width, self.height, pixels, meta

--- a/code/png.py
+++ b/code/png.py
@@ -1917,6 +1917,10 @@ class Reader:
             a = getattr(self, attr, None)
             if a is not None:
                 meta[attr] = a
+        if getattr(self, 'x_pixels_per_unit', None):
+            meta['physical'] = {'x': self.x_pixels_per_unit,
+                                'y': self.y_pixels_per_unit,
+                                'unit_is_meter': self.unit_is_meter}
         if self.plte:
             meta['palette'] = self.palette()
         return self.width, self.height, pixels, meta

--- a/code/test_png.py
+++ b/code/test_png.py
@@ -722,9 +722,6 @@ class Test(unittest.TestCase):
         expected_dict = {'x': 2, 'y': 1, 'unit_is_meter': False}
         self.assertEqual(expected_dict, meta['physical'])
 
-
-
-
     def testModifyRows(self):
         # Tests that the rows yielded by the pixels generator
         # can be safely modified.

--- a/code/test_png.py
+++ b/code/test_png.py
@@ -705,8 +705,12 @@ class Test(unittest.TestCase):
         self.assertEqual(2, reader.x_pixels_per_unit)
         self.assertEqual(1, reader.y_pixels_per_unit)
         self.assert_(reader.unit_is_meter)
-        expected_dict = {'x': 2, 'y': 1, 'unit_is_meter': True}
-        self.assertEqual(expected_dict, meta['physical'])
+        expected = (2, 1, True)
+        self.assertEqual(expected, meta['physical'])
+        res = meta['physical']
+        self.assertEqual(2, res.x)
+        self.assertEqual(1, res.y)
+        self.assert_(res.unit_is_meter)
         # = 2nd check
         out = BytesIO()
         writer = png.Writer(width=width, height=height, greyscale=True,
@@ -719,8 +723,12 @@ class Test(unittest.TestCase):
         self.assertEqual(2, reader.x_pixels_per_unit)
         self.assertEqual(1, reader.y_pixels_per_unit)
         self.assert_(not reader.unit_is_meter)
-        expected_dict = {'x': 2, 'y': 1, 'unit_is_meter': False}
-        self.assertEqual(expected_dict, meta['physical'])
+        expected = (2, 1, False)
+        self.assertEqual(expected, meta['physical'])
+        res = meta['physical']
+        self.assertEqual(2, res.x)
+        self.assertEqual(1, res.y)
+        self.assertFalse(res.unit_is_meter)
 
     def testModifyRows(self):
         # Tests that the rows yielded by the pixels generator

--- a/code/test_png.py
+++ b/code/test_png.py
@@ -684,7 +684,7 @@ class Test(unittest.TestCase):
         height = width
         out = BytesIO()
         # = Check if pHYs chunk is omitted by default
-        writer = png.Writer(width=width, height=height)
+        writer = png.Writer(width=width, height=height, greyscale=True)
         writer.write(out, pixels)
         out.seek(0)
         self.assert_(b'pHYs' not in out.getvalue())
@@ -695,8 +695,8 @@ class Test(unittest.TestCase):
         self.assert_(not hasattr(reader, 'x_pixels_per_unit'))
         # = Check if pHYs chunk is generated
         out = BytesIO()
-        writer = png.Writer(width=width, height=height, x_pixels_per_unit=2,
-                            y_pixels_per_unit=1, unit_is_meter=True)
+        writer = png.Writer(width=width, height=height, greyscale=True,
+                            x_pixels_per_unit=2, y_pixels_per_unit=1, unit_is_meter=True)
         writer.write(out, pixels)
         out.seek(0)
         reader = png.Reader(file=out)
@@ -709,8 +709,8 @@ class Test(unittest.TestCase):
         self.assertEqual(expected_dict, meta['physical'])
         # = 2nd check
         out = BytesIO()
-        writer = png.Writer(width=width, height=height, x_pixels_per_unit=2,
-                            y_pixels_per_unit=1, unit_is_meter=False)
+        writer = png.Writer(width=width, height=height, greyscale=True,
+                            x_pixels_per_unit=2, y_pixels_per_unit=1, unit_is_meter=False)
         writer.write(out, pixels)
         out.seek(0)
         reader = png.Reader(file=out)

--- a/man/chunk.rst
+++ b/man/chunk.rst
@@ -120,7 +120,10 @@ Ignored when reading.  Not generated.
 ``pHYs``
 ^^^^^^^^
 
-Ignored when reading.  Not generated.
+When a PNG image is read, a ``pHYs`` chunk will add the ``phys`` key to
+the ``info`` dictionary. When writing a PNG image, a ``pHYs`` chunk will
+be generated if ``x_pixels_per_unit`` and ``y_pixels_per_unit`` is not ``None``
+(default: ``None``).
 
 ``sPLT``
 ^^^^^^^^


### PR DESCRIPTION
An alternative approach to provide information about "pHYs" chunk: Use named tuple instead of a dict. 

Does the same as #70 but uses a named tuple (requires Py >= 2.6)

Closes #69
