### PR TITLE
if bitsperpixel is 1, the image must be grey

### DIFF
--- a/code/png.py
+++ b/code/png.py
@@ -545,6 +545,8 @@ class Writer:
         if bitdepth > 8 and palette:
             raise ValueError(
                 "bit depth must be 8 or less for images with palette")
+        if bitdepth == 1:
+            greyscale = Tru
 
         transparent = check_color(transparent, greyscale, 'transparent')
         background = check_color(background, greyscale, 'background')


### PR DESCRIPTION
if bitsperpixel is 1, the image must be grey. Currently, the following code produces 24bits RGB PNG

``` python
f = open('1bit.png', 'wb')
writer = png.Writer(3, 5, bitdepth=1)
pixel = [(0,1,0),(0,1,0),(1,1,1),(0,1,0),(0,1,0)]
writer.write(f, pixel) ; f.close()
```
