### PR TITLE
Remove Python 3.2, 3.3, Add Python 3.6, 3.7 and flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 matrix:
   include:
     - python: "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
-install: true
+  - "3.6"
+install: pip install flake8
+before_script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 script: cd code; nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: python
 sudo: false
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+matrix:
+  include:
+    - python: "2.6"
+      install: true  # flake8 no longer supports Python 2.6
+      before_script: true
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "3.7"
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 install: pip install flake8
 before_script: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 script: cd code; nosetests


### PR DESCRIPTION
* Remove Python ~2.6,~ 3.2, and 3.3 because they are now [__end of life__](https://devguide.python.org/#branchstatus).
* Add Python 3.6 and 3.7
* Test with [__flake8__](http://flake8.pycqa.org/) and stop the build if there are Python syntax errors or undefined names