### PR TITLE
Fix error in example code

### DIFF
--- a/man/ex.rst
+++ b/man/ex.rst
@@ -97,7 +97,7 @@ the separate pixels; they have no meaning in the code. ::
   p = [(255,0,0, 0,255,0, 0,0,255),
        (128,0,0, 0,128,0, 0,0,128)]
   f = open('swatch.png', 'wb')
-  w = png.Writer(3, 2)
+  w = png.Writer(3, 2, greyscale=False)
   w.write(f, p)
   f.close()
 


### PR DESCRIPTION
The parameter `greyscale` is set to True by default. The incorrect example code did not specify `greyscale` to be False for use with a colour image, and was expecting 3 (grayscale) values per row instead of 9 (RGB).

The changes here now work on Python 2.7.15 and Python 3.6.8.

The previous error message was:
```
Traceback (most recent call last):
  File "test.py", line 6, in <module>
    w.write(f, p)
  File "/home/victor/.local/lib/python3.6/site-packages/png.py", line 670, in write
    nrows = self.write_passes(outfile, check_rows(rows))
  File "/home/victor/.local/lib/python3.6/site-packages/png.py", line 704, in write_passes
    return self.write_packed(outfile, rows)
  File "/home/victor/.local/lib/python3.6/site-packages/png.py", line 736, in write_packed
    for i, row in enumerate(rows):
  File "/home/victor/.local/lib/python3.6/site-packages/png.py", line 662, in check_rows
    (vpr, len(row), i))
png.ProtocolError: ProtocolError: Expected 3 values but got 9 value, in row 0
```