### PR TITLE
remove unneeded imports, some minor optimizations, drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
     python: "3.6"
     script:
     - flake8 . --count --show-source --statistics
-  - python: "3.4"
   - python: "3.5"
   - python: "3.6"
   - python: "3.7"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ in the `man/` directory.
 ## INSTALLATION
 
 PyPNG is pure Python and has no dependencies.
-It requires Python 3.4 or any compatible higher version.
+It requires Python 3.5 or any compatible higher version.
 
 To install PyPNG package via pip use:
 
@@ -60,7 +60,7 @@ your current directory:
 ### Release 0.0.21 (not released yet)
 
 Support for Python 2 is dropped.
-Python 3.4 and onwards are supported.
+Python 3.5 and onwards are supported.
 
 ### Release 0.0.20
 

--- a/code/pipcolours
+++ b/code/pipcolours
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 """
 pipcolours - extract all colours present in source image.
 Produces a PNG that has each colour exactly once.
@@ -14,7 +12,6 @@ if all pixels are opaque, output PNG has no alpha channel.
 import argparse
 import collections
 import itertools
-import sys
 
 import png
 
@@ -148,6 +145,8 @@ def reduce_alpha(col, planes, bitdepth):
 
 
 def main(argv=None):
+    import sys
+
     if argv is None:
         argv = sys.argv
 

--- a/code/pipcomposite
+++ b/code/pipcomposite
@@ -17,8 +17,6 @@ It is valid for the input to have no alpha channel, but it doesn't
 make much sense: the output will equal the input.
 """
 
-import sys
-
 def composite(out, inp, background):
     import png
 

--- a/code/png.py
+++ b/code/png.py
@@ -60,7 +60,7 @@ and understood (when reading): ``tRNS``, ``bKGD``, ``gAMA``.
 The ``sBIT`` chunk can be used to specify precision for
 non-native bit depths.
 
-Requires Python 3.4 or higher.
+Requires Python 3.5 or higher.
 Installation is trivial,
 but see the ``README.txt`` file (with the source distribution) for details.
 
@@ -168,8 +168,6 @@ but may be just right if the source data for
 the PNG image comes from something that uses a similar format
 (for example, 1-bit BMPs, or another PNG file).
 """
-
-from __future__ import print_function
 
 __version__ = "0.0.20"
 

--- a/code/pnghist
+++ b/code/pnghist
@@ -7,7 +7,6 @@
 
 from array import array
 import getopt
-import sys
 
 import png
 

--- a/code/pngsuite.py
+++ b/code/pngsuite.py
@@ -19,12 +19,9 @@ Also a delicious command line tool.
 
 def _dehex(s):
     """Liberally convert from hex string to binary string."""
-    import re
     import binascii
 
-    # Remove all non-hexadecimal digits
-    s = re.sub(br'[^a-fA-F\d]', b'', s)
-    return binascii.unhexlify(s)
+    return binascii.unhexlify(s.replace(b"\n", b""))
 
 
 # Copies of PngSuite test files taken

--- a/code/prichunkpng
+++ b/code/prichunkpng
@@ -2,8 +2,6 @@
 # pngchunk
 # Chunk editing/extraction tool.
 
-from __future__ import print_function
-
 import argparse
 import collections
 
@@ -11,8 +9,6 @@ import collections
 import io
 import string
 import struct
-import sys
-import warnings
 import zlib
 
 # Local module.
@@ -164,6 +160,7 @@ def hex_color(s):
 
 
 def main(argv=None):
+    import sys
     import re
 
     if argv is None:

--- a/code/priforgepng
+++ b/code/priforgepng
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # priforgepng
 
-from __future__ import print_function
-
 """Forge PNG image from raw computation."""
 
 from array import array

--- a/code/prigreypng
+++ b/code/prigreypng
@@ -6,7 +6,6 @@
 # change.
 
 import argparse
-import sys
 
 from array import array
 
@@ -68,4 +67,5 @@ def main(argv=None):
 
 
 if __name__ == "__main__":
+    import sys
     sys.exit(main())

--- a/code/pripalpng
+++ b/code/pripalpng
@@ -2,17 +2,12 @@
 # pripalpng
 # Convert to Palette PNG
 
-from __future__ import print_function
-
 import argparse
 import collections
 
 # https://docs.python.org/2.7/library/io.html
 import io
 import string
-import struct
-import sys
-import warnings
 import zlib
 
 # Local module.
@@ -91,6 +86,7 @@ def asRGBorA8(reader):
 
 
 def main(argv=None):
+    import sys
     import re
 
     if argv is None:

--- a/code/pripamtopng
+++ b/code/pripamtopng
@@ -4,8 +4,6 @@
 #
 # Python Raster Image PAM to PNG
 
-from __future__ import print_function
-
 import struct
 import sys
 

--- a/code/pripnglsch
+++ b/code/pripnglsch
@@ -2,12 +2,6 @@
 # pripnglsch
 # PNG List Chunks
 
-from __future__ import print_function
-
-import argparse
-import binascii
-import sys
-
 import png
 
 
@@ -16,19 +10,17 @@ def list_chunks(out, inp):
     for t, v in r.chunks():
         add = ""
         if len(v) <= 28:
-            add = " " + hex(v)
+            add = " " + v.hex()
         else:
-            add = " " + hex(v[:26]) + "..."
+            add = " " + v[:26].hex() + "..."
         t = t.decode("ascii")
         print("%s %10d%s" % (t, len(v), add), file=out)
 
 
-def hex(bs):
-    """Convert the bytes `bs` to a hex string."""
-    return binascii.hexlify(bs).decode("ascii")
-
-
 def main(argv=None):
+    import argparse
+    import sys
+
     parser = argparse.ArgumentParser()
     parser.add_argument("png", nargs="?", default="-")
     args = parser.parse_args()

--- a/code/pripngtopam
+++ b/code/pripngtopam
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
-import argparse
 import struct
-import sys
 
 import png
 
@@ -63,6 +59,8 @@ def write_pnm(file, rows, meta):
 
 
 def main(argv=None):
+    import argparse
+
     parser = argparse.ArgumentParser(description="Convert PNG to PAM")
     parser.add_argument("png", nargs="?", default="-")
 
@@ -77,4 +75,6 @@ def main(argv=None):
 
 
 if __name__ == "__main__":
+    import sys
+
     sys.exit(main())

--- a/code/priweavepng
+++ b/code/priweavepng
@@ -4,13 +4,8 @@
 # Weave selected channels from input PNG files into
 # a multi-channel output PNG.
 
-from __future__ import print_function
-
-import argparse
 import collections
-import itertools
 import re
-import sys
 
 from array import array
 
@@ -190,6 +185,10 @@ def comma_list(s):
 
 
 def main(argv=None):
+    import argparse
+    import itertools
+    import sys
+
     if argv is None:
         argv = sys.argv
     argv = argv[1:]

--- a/code/test_png.py
+++ b/code/test_png.py
@@ -14,8 +14,6 @@
 # If you have nose installed you can use that:
 #   nosetests .
 
-from __future__ import print_function
-
 import glob
 import itertools
 import os

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ https://pypng.readthedocs.io/en/latest/
       'Topic :: Software Development :: Libraries :: Python Modules',
       'Programming Language :: Python',
       'Programming Language :: Python :: 3',
-      'Programming Language :: Python :: 3.4',
       'Programming Language :: Python :: 3.5',
       'Programming Language :: Python :: 3.6',
       'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
move some imports to main functions instead of top of file, removed unused, since we're dropping Python 2 support that includes the `from __future__ import print_function`

use `struct.unpack_from()` in place of `struct.unpack()` of slices in iccp.py, it's faster (in cPython) since it doesn't make copies

use `bytes.hex()` and `bytes.fromhex()` where appropriate
`bytes.hex()` breaks Python 3.4 compatibility, but that's fine IMO since 3.4 is officially dead anyway