### PR TITLE
Writer.write(): Raise correct ProtocolError on empty write and consistently returns count of rows written

### DIFF
--- a/code/png.py
+++ b/code/png.py
@@ -670,6 +670,7 @@ class Writer:
             raise ProtocolError(
                 "rows supplied (%d) does not match height (%d)" %
                 (nrows, self.height))
+        return nrows
 
     def write_passes(self, outfile, rows):
         """
@@ -833,9 +834,15 @@ class Writer:
                 # Coerce to array type
                 fmt = 'BH'[self.bitdepth > 8]
                 pixels = array(fmt, pixels)
-            self.write_passes(outfile, self.array_scanlines_interlace(pixels))
+            return self.write_passes(
+                outfile,
+                self.array_scanlines_interlace(pixels)
+            )
         else:
-            self.write_passes(outfile, self.array_scanlines(pixels))
+            return self.write_passes(
+                outfile,
+                self.array_scanlines(pixels)
+            )
 
     def array_scanlines(self, pixels):
         """

--- a/code/png.py
+++ b/code/png.py
@@ -731,8 +731,9 @@ class Writer:
         # it's compressed when sufficiently large.
         data = bytearray()
 
-        # raise i scope out of the for loop
-        i = 0
+        # raise i scope out of the for loop. set to -1, because the for loop
+        # sets i to 0 on the first pass
+        i = -1
         for i, row in enumerate(rows):
             # Add "None" filter type.
             # Currently, it's essential that this filter type be used

--- a/code/png.py
+++ b/code/png.py
@@ -731,6 +731,8 @@ class Writer:
         # it's compressed when sufficiently large.
         data = bytearray()
 
+        # raise i scope out of the for loop
+        i = 0
         for i, row in enumerate(rows):
             # Add "None" filter type.
             # Currently, it's essential that this filter type be used

--- a/code/test_png.py
+++ b/code/test_png.py
@@ -413,6 +413,21 @@ class Test(unittest.TestCase):
             "ProtocolError: rows supplied (0) does not match height (1)"
         )
 
+    def test_write_length(self):
+        """Test row length is returned consistently from Writer.write()
+        """
+        w = png.Writer(1, 2)
+        o = BytesIO()
+        empty = [[1], [1]]
+        row_count = w.write(o, empty)
+        self.assertEqual(row_count, 2)
+
+        w = png.Writer(1, 2, interlace=True)
+        o = BytesIO()
+        empty = [[1], [1]]
+        row_count = w.write(o, empty)
+        self.assertEqual(row_count, 2)
+
     def test_write_background_colour(self):
         """Test that background keyword works."""
 

--- a/code/test_png.py
+++ b/code/test_png.py
@@ -388,6 +388,24 @@ class Test(unittest.TestCase):
         info = r.read()[3]
         png.Writer(**info)
 
+    def test_write_empty(self):
+        """Test writing an empty file without the expected error.
+        """
+        w = png.Writer(1, 1)
+        o = BytesIO()
+        empty = []
+
+        try:
+            w.write(o, empty)
+        except UnboundLocalError as e:
+            """
+            Protect against:
+            File "test_png.py", line 399, in test_write_empty
+              w.write(o, empty)
+            UnboundLocalError: local variable 'i' referenced before assignment
+            """
+            self.fail("UnexpectedLocalError exception: {}".format(e))
+
     def test_write_background_colour(self):
         """Test that background keyword works."""
 

--- a/code/test_png.py
+++ b/code/test_png.py
@@ -389,22 +389,29 @@ class Test(unittest.TestCase):
         png.Writer(**info)
 
     def test_write_empty(self):
-        """Test writing an empty file without the expected error.
+        """Test writing an empty file expecting an error.
         """
         w = png.Writer(1, 1)
         o = BytesIO()
         empty = []
 
-        try:
-            w.write(o, empty)
-        except UnboundLocalError as e:
-            """
-            Protect against:
-            File "test_png.py", line 399, in test_write_empty
-              w.write(o, empty)
-            UnboundLocalError: local variable 'i' referenced before assignment
-            """
-            self.fail("UnexpectedLocalError exception: {}".format(e))
+        with self.assertRaises(png.ProtocolError) as cm:
+            try:
+                w.write(o, empty)
+            except UnboundLocalError as e:
+                """
+                Protect against:
+                File "test_png.py", line 399, in test_write_empty
+                w.write(o, empty)
+                UnboundLocalError: local variable 'i' referenced before
+                assignment
+                """
+                self.fail("UnexpectedLocalError exception: {}".format(e))
+
+        self.assertEqual(
+            str(cm.exception),
+            "ProtocolError: rows supplied (0) does not match height (1)"
+        )
 
     def test_write_background_colour(self):
         """Test that background keyword works."""


### PR DESCRIPTION
Discovered these issues while working through a new PNG generator script. My row data object was unintentionally empty and failed correctly, but with the wrong error:
```
               File "test_png.py", line 399, in test_write_empty
                w.write(o, empty)
                UnboundLocalError: local variable 'i' referenced before assignment
```
* The first commit contains a new test reproducing the error and failing the tests.
* The following two commits fix and test for the correct ProtocolError raise.
* The final commit resolves a related inconsistency.