### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,19 @@ matrix:
   - python: "3.5"
   - python: "3.6"
   - python: "3.7"
+ # ppc64le support code
+  - name: flake8
+    arch: ppc64le
+    install: pip install flake8
+    python: "3.6"
+    script:
+    - flake8 . --count --show-source --statistics
+  - python: "3.5"
+    arch: ppc64le
+  - python: "3.6"
+    arch: ppc64le
+  - python: "3.7"
+    arch: ppc64le
     dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
 script:
   - cd code


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/pypng