### PR TITLE
docs: Fix a few typos

### DIFF
--- a/code/png.py
+++ b/code/png.py
@@ -346,7 +346,7 @@ class ChunkError(FormatError):
 
 
 class Default:
-    """The default for the greyscale paramter."""
+    """The default for the greyscale parameter."""
 
 
 class Writer:
@@ -500,10 +500,10 @@ class Writer:
         Values from 1 to 9 (highest) specify compression.
         0 means no compression.
         -1 and ``None`` both mean that the ``zlib`` module uses
-        the default level of compession (which is generally acceptable).
+        the default level of compression (which is generally acceptable).
 
         If `interlace` is true then an interlaced image is created
-        (using PNG's so far only interace method, *Adam7*).
+        (using PNG's so far only interlace method, *Adam7*).
         This does not affect how the pixels should be passed in,
         rather it changes how they are arranged into the PNG file.
         On slow connexions interlaced images can be

--- a/code/test_png.py
+++ b/code/test_png.py
@@ -1178,7 +1178,7 @@ class Test(unittest.TestCase):
         )
 
     def test_palette_transparent(self):
-        """Palette is incompatible with transarent."""
+        """Palette is incompatible with transparent."""
         self.assertRaises(
             png.ProtocolError,
             png.Writer,


### PR DESCRIPTION
There are small typos in:
- code/png.py
- code/test_png.py

Fixes:
- Should read `parameter` rather than `paramter`.
- Should read `transparent` rather than `transarent`.
- Should read `interlace` rather than `interace`.
- Should read `compression` rather than `compession`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md